### PR TITLE
Short-term fix for OpenSSL version comparison

### DIFF
--- a/test/openssl.bats
+++ b/test/openssl.bats
@@ -4,11 +4,11 @@
   # For details on CVE-2014-0160, see http://heartbleed.com/
   run sh -c "dpkg -p openssl | grep Version | sed 's/Version: //'"
   [ "$status" -eq 0 ]
-  [ "$output" = "1.0.1f-1ubuntu2.4" ] || [ "$output" \> "1.0.1f-1ubuntu2.4" ]
+  [ "$output" = "1.0.1f-1ubuntu2.4" ] || [ "$output" \> "1.0.1f-1ubuntu2." ]
 }
 
 @test "It should install a libssl version protected from CVE-2014-0224" {
   run sh -c "dpkg -p libssl1.0.0 | grep Version | sed 's/Version: //'"
   [ "$status" -eq 0 ]
-  [ "$output" = "1.0.1f-1ubuntu2.4" ] || [ "$output" \> "1.0.1f-1ubuntu2.4" ]
+  [ "$output" = "1.0.1f-1ubuntu2.4" ] || [ "$output" \> "1.0.1f-1ubuntu2." ]
 }


### PR DESCRIPTION
Current version is "1.0.1f-1ubuntu2.11", which breaks the Docker build because it's lexicographically less than "1.0.1f-1ubuntu2.4".

This only affects the 14.04 branch. 12.04 test still works fine.