### PR TITLE
added ubuntu:xenial-20171006 tag 

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,7 @@ env:
     - TAG=12.04
     - TAG=14.04
     - TAG=16.04
+    - TAG=xenial-20171006
 
 script:
   - make build

--- a/Makefile
+++ b/Makefile
@@ -75,7 +75,7 @@ push: build
 	set -e ; \
 	for registry in $(PUSH_REGISTRIES); do \
 		for tag in $(PUSH_TAGS); do \
-			docker tag -f "$(REGISTRY)/$(REPOSITORY):$(TAG)" "$${registry}/$(REPOSITORY):$${tag}"; \
+			docker tag "$(REGISTRY)/$(REPOSITORY):$(TAG)" "$${registry}/$(REPOSITORY):$${tag}"; \
 			docker push "$${registry}/$(REPOSITORY):$${tag}"; \
 		done \
 	done
@@ -88,7 +88,7 @@ test: build
 build: $(TAG)/Dockerfile
 	docker build -t "$(REGISTRY)/$(REPOSITORY):$(TAG)" -f "$(TAG)/Dockerfile" .
 ifeq "$(TAG)" "$(LATEST_TAG)"
-	docker tag -f "$(REGISTRY)/$(REPOSITORY):$(TAG)" "$(REGISTRY)/$(REPOSITORY):latest"
+	docker tag "$(REGISTRY)/$(REPOSITORY):$(TAG)" "$(REGISTRY)/$(REPOSITORY):latest"
 endif
 
 

--- a/xenial-20171006/config.mk
+++ b/xenial-20171006/config.mk
@@ -1,0 +1,2 @@
+export LIBC_MIN = 2.23-0ubuntu9
+export LIBSSL_MIN = 1.0.2g-1ubuntu4.8 # Never affected


### PR DESCRIPTION
There is a new tag for ubuntu:16.04 docker image xenial-20171006 with a lot of security updates. 
The upgrade to xenial-20171006 (16.04.3) fixes a lot of issues that appcanary suggests fixing. 

Please review @fancyremarker, @krallin 