### PR TITLE
Add tzdata package

### DIFF
--- a/Dockerfile.erb
+++ b/Dockerfile.erb
@@ -3,8 +3,8 @@ MAINTAINER Frank Macreery <frank@macreery.com>
 
 ADD files/usr/bin/apt-install /usr/bin/apt-install
 
-# Install Git
-RUN apt-install git
+# Install Git and tzdata. Those are usually needed in customer containers.
+RUN apt-install git tzdata
 
 # Install latest security updates now, and on build
 RUN grep security /etc/apt/sources.list > /tmp/security.list


### PR DESCRIPTION
This package used to be in the base Ubuntu image, but it no longer is.
We have a number of customers depending on it, and its removal caught
them off-guard.

tzdata is a fairly big package (~3MB), so we normally would rather *not*
include it in a base image, but in practice, it's depended on in a large
number of customer containers, such that we might even prefer to include
it in the base image to maximize reuse.

---

cc @fancyremarker 