### PR TITLE
Add support for 18.04

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,7 @@ env:
     - TAG=12.04
     - TAG=14.04
     - TAG=16.04
+    - TAG=18.04
 
 script:
   - make build

--- a/18.04/config.mk
+++ b/18.04/config.mk
@@ -1,0 +1,2 @@
+export LIBC_MIN = 2.21-0ubuntu6
+export LIBSSL_MIN = 1.0.1f-1ubuntu2 # Never affected

--- a/Dockerfile.erb
+++ b/Dockerfile.erb
@@ -21,7 +21,7 @@ ONBUILD RUN SECURITY_LIST=$(mktemp) \
  && rm "$SECURITY_LIST"
 
 # Install Git and tzdata. Those are usually needed in customer containers.
-RUN apt-install git tzdata
+RUN DEBIAN_FRONTEND=noninteractive apt-install git tzdata
 
 # Install Bats
 RUN git clone https://github.com/sstephenson/bats.git /tmp/bats && \

--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ Ubuntu base image with custom Aptible patches and Dockerfile building tools.
 
 ## Available Tags
 
+* `18.04`: Ubuntu 18.04 (LTS)
 * `16.04`: Ubuntu 16.04 (LTS)
 * `latest`: Ubuntu 14.04 (LTS)
 * `14.04`: Ubuntu 14.04 (LTS)


### PR DESCRIPTION
No Aptible repositories seem to rely on `latest`. Only one client seems to have Dockerfile deployed `latest` recently.  Should make announcement before changing the latest target, but we can release 18.04 now.
